### PR TITLE
Reference source files directly from example code

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render } from 'react-dom';
-import RichTextEditor, { Toolbar, Body } from '../lib';
+import RichTextEditor, { Toolbar, Body } from '../src';
 import itemOptions from './itemOptions';
-import '../lib/base.css';
+import '../node_modules/draft-js/dist/Draft.css';
 import './index.styl';
 
 let rte;


### PR DESCRIPTION
I changed to reference source files directly from example code.

We don't need to pre-compiled source code because the example project is
using webpack.