### PR TITLE
Delay re-forcusing checkboxes on Safari

### DIFF
--- a/src/Body.js
+++ b/src/Body.js
@@ -89,7 +89,7 @@ export default class Body extends Component {
     // FIXME ;(   does not respond check box in the Safari
     if (this._isSafari && target.nodeName.toLowerCase() === 'input' && target.type === 'checkbox') {
       this.blur();
-      this.focus();
+      setTimeout(() => this.focus(), 100);
     }
   }
   _shouldHidePlaceholder() {


### PR DESCRIPTION
This fixes this:

![may-12-2016 11-39-07](https://cloud.githubusercontent.com/assets/18631/15202524/463e3556-1836-11e6-8a1e-49c6c49ce50d.gif)


