### PR TITLE
Add onKeyDown props

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -23,6 +23,7 @@ export default class RichTextEditor extends Component {
     readOnly: PropTypes.bool,
     onReturnWithCommand: PropTypes.func,
     onPastedFiles: PropTypes.func,
+    onKeyDown: PropTypes.func,
     customAtomicBlockRendererFn: PropTypes.func,
     atomicBlockRenderMap: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.element, PropTypes.func])),
     onCompleteFileUpload: PropTypes.func
@@ -152,6 +153,7 @@ export default class RichTextEditor extends Component {
           editorState={editorState}
           readOnly={readOnly}
           onChange={this.changeEditorState}
+          onKeyDown={this.props.onKeyDown}
           placeholder={placeholder}
         />
       </div>


### PR DESCRIPTION
Because there is some bug on Android that input enter key causes to blur `contenteditable`, 
I added `onKeyDown` prop to `RichTextEditor` that is delegated to internal `Editor`.