### PR TITLE
Deliver stripPastedStyles props

### DIFF
--- a/examples/Editor.js
+++ b/examples/Editor.js
@@ -10,6 +10,12 @@ import 'prism-github/prism-github.css';
 import './index.styl';
 
 export default class Editor extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isStripPastedStyles: window.clipboardData ? true : false,
+    };
+  }
   handleClickInsertImage = () => {
     const url = window.prompt('Enter a image URL.');
     if (url) {
@@ -56,6 +62,7 @@ export default class Editor extends Component {
           [FILE_PLACEHOLDER]: FilePlaceholder
         }}
         rawMentions={mentions}
+        stripPastedStyles={this.state.isStripPastedStyles}
       >
         {this.renderToolbar()}
       </OneteamRTE>

--- a/examples/Editor.js
+++ b/examples/Editor.js
@@ -10,12 +10,7 @@ import 'prism-github/prism-github.css';
 import './index.styl';
 
 export default class Editor extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isStripPastedStyles: window.clipboardData ? true : false,
-    };
-  }
+  state = { isStripPastedStyles: window.clipboardData ? true : false }
   handleClickInsertImage = () => {
     const url = window.prompt('Enter a image URL.');
     if (url) {

--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -43,12 +43,14 @@ export default class RichTextEditor extends Component {
     rawMentions: PropTypes.arrayOf(
       PropTypes.oneOfType([userMentionType, groupMentionType])
     ),
-    disableWebCardCreation: PropTypes.bool
+    disableWebCardCreation: PropTypes.bool,
+    stripPastedStyles: PropTypes.bool,
   }
   static defaultProps = {
     placeholder: 'Contents here...',
     readOnly: false,
-    initialHtml: ''
+    initialHtml: '',
+    stripPastedStyles: false,
   }
   set html(html) {
     const { editorState, mentionSuggestions } = this.state;
@@ -172,7 +174,7 @@ export default class RichTextEditor extends Component {
   }
   render() {
     const { editorState } = this.state;
-    const { className, readOnly, placeholder, onError, onRerenderedAfterError } = this.props;
+    const { className, readOnly, placeholder, onError, onRerenderedAfterError, stripPastedStyles } = this.props;
     const bodyClassName = classNames(
       'rich-text-editor-body',
       { 'RichEditor-hidePlaceholder': this._shouldHidePlaceholder() },
@@ -195,6 +197,7 @@ export default class RichTextEditor extends Component {
               onChange={this.changeEditorState}
               onKeyDown={this.props.onKeyDown}
               placeholder={placeholder}
+              stripPastedStyles={stripPastedStyles}
             />
             <this.emojiPlugin.EmojiSuggestions />
             <this.mentionPlugin.MentionSuggestions


### PR DESCRIPTION
IEでコピーされたテキストの改行が反映されないため、プレーンテキストとしてペーストできるように `stripPastedStyles` を受け渡せるようにしました。