### PR TITLE
Use styled-components for handling css

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "prop-types": "^15.6.2",
     "react-bootstrap": "^0.32.1",
     "react-minimal-error-boundary": "^1.0.1",
-    "react-oneteam": "^0.4.7"
+    "react-oneteam": "^0.4.7",
+    "styled-components": "3.4.9"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",

--- a/src/plugins/hashtagList/index.js
+++ b/src/plugins/hashtagList/index.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import createPluginObject, { defaultTheme } from 'draft-js-mention-plugin';
-import './style.css';
+import createPluginObject from 'draft-js-mention-plugin';
+import styled from 'styled-components';
 
 /**
  * convert string[] into { id: string; name: string;  userName: string; email: string;}[]
@@ -10,16 +9,19 @@ import './style.css';
 export const convertToMentions = hashtagList =>
   hashtagList.map((name, i) => ({ id: `hashtag-item-${i}`, name, userName: '', email: '' }));
 
-const MentionComponent = ({ children, theme }) => (
-  <span className={classnames(theme.mention, theme.hashtag)}>{children}</span>
-);
-MentionComponent.propTypes = { children: PropTypes.array, theme: PropTypes.object };
+const Wrapper = styled.span`
+  font-weight: bold;
+  background: #fff !important;
+`;
+
+const MentionComponent = ({ children }) => <Wrapper>{children}</Wrapper>;
+
+MentionComponent.propTypes = { children: PropTypes.array };
 
 // TODO: replace with a dedicated hashtag suggestion plugin which has no dependency on 'draft-js-mention-plugin'
 // Ad hoc support for hashtag suggest on rich text editor
 export default hashtagList =>
   createPluginObject({
-    theme: { ...defaultTheme, hashtag: 'draft-js-mention-plugin-hashtag' },
     mentionPrefix: '',
     mentionTrigger: '#',
     mentions: convertToMentions(hashtagList),

--- a/src/plugins/hashtagList/style.css
+++ b/src/plugins/hashtagList/style.css
@@ -1,5 +1,0 @@
-.draft-js-mention-plugin-hashtag span,
-.draft-js-mention-plugin-hashtag {
-  font-weight: bold;
-  background: #fff !important;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,6 +1140,13 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+buffer@^5.0.3:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.0.tgz#33294f5c1f26e08461e528b69fa06de3c45cbd8c"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -1205,6 +1212,10 @@ camelcase@^3.0.0:
 camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+
+camelize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
 
 caniuse-api@^1.5.2:
   version "1.6.1"
@@ -1601,6 +1612,10 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -1644,6 +1659,14 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-to-react-native@^2.0.3:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.1.tgz#cf0f61e0514846e2d4dc188b0886e29d8bef64a2"
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^3.3.0"
 
 css-what@2.1:
   version "2.1.0"
@@ -3765,7 +3788,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
@@ -3795,7 +3818,7 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-macaddress@^0.2.9:
+macaddress@^0.2.8:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.9.tgz#3579b8b9acd5b96b4553abf0f394185a86813cb3"
 
@@ -4813,6 +4836,14 @@ prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.5.4:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
@@ -5014,6 +5045,10 @@ react-icons@^2.2.7:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-2.2.7.tgz#d7860826b258557510dac10680abea5ca23cf650"
   dependencies:
     react-icon-base "2.1.0"
+
+react-is@^16.3.1, react-is@^16.8.1:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
 
 react-minimal-error-boundary@^1.0.1:
   version "1.0.1"
@@ -5826,6 +5861,28 @@ style-loader@^0.20.2:
     loader-utils "^1.1.0"
     schema-utils "^0.4.3"
 
+styled-components@3.4.9:
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.4.9.tgz#519abeb351b37be5b7de6a15ff9e4efeb9d772da"
+  dependencies:
+    buffer "^5.0.3"
+    css-to-react-native "^2.0.3"
+    fbjs "^0.8.16"
+    hoist-non-react-statics "^2.5.0"
+    prop-types "^15.5.4"
+    react-is "^16.3.1"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^3.2.3"
+
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+
+stylis@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+
 stylus-loader@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/stylus-loader/-/stylus-loader-3.0.1.tgz#77f4b34fd030d25b2617bcf5513db5b0730c4089"
@@ -6157,7 +6214,7 @@ uniqid@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/uniqid/-/uniqid-4.1.1.tgz#89220ddf6b751ae52b5f72484863528596bb84c1"
   dependencies:
-    macaddress "^0.2.9"
+    macaddress "^0.2.8"
 
 uniqs@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## objective

Users can't build [the latest release version](https://www.npmjs.com/package/oneteam-rte/v/2.1.19
).

```sh
ERROR in ./node_modules/oneteam-rte/es/plugins/hashtagList/index.js
Module not found: Error: Can't resolve './style.css' in ...
```

This PR fixes it.


## problem

- `.css` files are **not bundled** in npm package because babel does not handle `.css` files unlike webpack.
