### PR TITLE
ハッシュタグのサジェストリストにクラス名をセットする

### DIFF
--- a/examples/index.styl
+++ b/examples/index.styl
@@ -239,3 +239,6 @@ $toolbar-hover-background-color = rgba(#333, 0.04)
 // custom hashtag style example
 .draft-js-mention-plugin-hashtag-custom
   background: #ccc !important
+.is-hashtag-suggest {
+  background: #ebebeb;
+}

--- a/src/plugins/hashtagList/index.js
+++ b/src/plugins/hashtagList/index.js
@@ -23,7 +23,11 @@ MentionComponent.propTypes = { children: PropTypes.array, theme: PropTypes.objec
 // Ad hoc support for hashtag suggest on rich text editor
 export default hashtagList =>
   createPluginObject({
-    theme: { ...defaultTheme, custom: 'draft-js-mention-plugin-hashtag-custom' },
+    theme: {
+      ...defaultTheme,
+      mentionSuggestions: `${defaultTheme.mentionSuggestions} is-hashtag-suggest`,
+      custom: 'draft-js-mention-plugin-hashtag-custom'
+    },
     mentionPrefix: '',
     mentionTrigger: '#',
     mentions: convertToMentions(hashtagList),


### PR DESCRIPTION
@joraku 

 - Jira https://oneteam-dev.atlassian.net/browse/TC-387

## gif

|**before**|**after**|
|--|--|
|<img width="823" alt=" 2020-02-10 at 3 16 26" src="https://user-images.githubusercontent.com/12182520/74107467-c3893600-4bb3-11ea-8e34-3ca983d728a7.png">|![after](https://user-images.githubusercontent.com/12182520/74107451-79a05000-4bb3-11ea-84c1-1de79f827c8f.gif)|

- ハッシュタグのサジェストリストには、 `.is-hashtag-suggest` をセットして、異なる見た目をメンションのサジェリトリストにセット可能にする