### PR TITLE
[TC-162] js-yaml のアップデート（yarn.lockのコミットが漏れていたので追加）

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4595,9 +4595,10 @@ react-minimal-error-boundary@^1.0.1:
     prop-types "^15.6.0"
     react-error-boundary "^1.2.1"
 
-react-oneteam@^0.4.7:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/react-oneteam/-/react-oneteam-0.4.7.tgz#d68739f598bb736401325971e51c28203f4b3d95"
+react-oneteam@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/react-oneteam/-/react-oneteam-0.4.8.tgz#5797ddb1cb89e11de59a7e71f3002f9fac2f8b56"
+  integrity sha512-cuGUaNrctTZeinBZtmF+4dIq9JHpDsVtstRLCF41+Oye722tT0JBGdOlwtoetjyCmYQM0Z6M/Cscp/BlMt26ow==
   dependencies:
     classnames "^2.2.5"
     color-hash "^1.0.3"


### PR DESCRIPTION
@joraku 

Jira: https://github.com/oneteam-dev/oneteam-rte/issues/158
Issue: #158 [TC-162] js-yaml のアップデート

目的
====
- [x] `react-oneteam@0.4.8` を使用する